### PR TITLE
Add google analytics 4 support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -60,3 +60,6 @@ titles_from_headings:
 #   - languages/index.md
 #   - process/speclet_playbook.md
 #   - process/testing_strategy.md
+
+
+google_analytics: G-2NX5YFW46E

--- a/_includes/body/analytics.html
+++ b/_includes/body/analytics.html
@@ -1,42 +1,16 @@
 {% if site.google_analytics %}
   <script>!function (w, d) {
+    /* this file can be removed once GA4 support is added upstream in hydejack */
+    /* See: https://github.com/hydecorp/hydejack/issues/310 */
+    /* This is a variation of the code in PR330 on hydejack */
+
+
     window.dataLayer = w.dataLayer || [];
     function gtag() {dataLayer.push(arguments);}
     gtag('js', new Date());
 
-    function gtagConsentDefaultOff() {
-      gtag('consent', 'default', {
-        'ad_storage': 'denied',
-        'analytics_storage': 'denied'
-      });
-    };
-
-    function gtagConsentUpdateOn() {
-      gtag('consent', 'update', {
-        'ad_storage': 'granted',
-        'analytics_storage': 'granted'
-      });
-    };
-
-    /*{% if site.hydejack.cookies_banner %}*/
-      if (navigator.CookiesOK) {
-        /* CookiesOK is not part of the navigator spec, not sure when this is true (extensions?) */
-        /* noop - we activate below */
-      } else if (d.cookie.indexOf("hy--cookies-ok=true") > -1) {
-        /* if cookies are opt-in only and opted for */
-        gtagConsentUpdateOn();
-      } else {
-        /* consent required and not yet given */
-        gtagConsentDefaultOff();
-      }
-    /*{% endif %}*/
-
     /* start tracking, will respect consent if set */
     gtag('config', '{{ site.google_analytics }}');
-
-    d.addEventListener('hy--cookies-ok', function () {
-      gtagConsentUpdateOn();
-    });
 
     w.loadJSDeferred('https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}');
   }(window, document);</script>

--- a/_includes/body/analytics.html
+++ b/_includes/body/analytics.html
@@ -1,0 +1,43 @@
+{% if site.google_analytics %}
+  <script>!function (w, d) {
+    window.dataLayer = w.dataLayer || [];
+    function gtag() {dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    function gtagConsentDefaultOff() {
+      gtag('consent', 'default', {
+        'ad_storage': 'denied',
+        'analytics_storage': 'denied'
+      });
+    };
+
+    function gtagConsentUpdateOn() {
+      gtag('consent', 'update', {
+        'ad_storage': 'granted',
+        'analytics_storage': 'granted'
+      });
+    };
+
+    /*{% if site.hydejack.cookies_banner %}*/
+      if (navigator.CookiesOK) {
+        /* CookiesOK is not part of the navigator spec, not sure when this is true (extensions?) */
+        /* noop - we activate below */
+      } else if (d.cookie.indexOf("hy--cookies-ok=true") > -1) {
+        /* if cookies are opt-in only and opted for */
+        gtagConsentUpdateOn();
+      } else {
+        /* consent required and not yet given */
+        gtagConsentDefaultOff();
+      }
+    /*{% endif %}*/
+
+    /* start tracking, will respect consent if set */
+    gtag('config', '{{ site.google_analytics }}');
+
+    d.addEventListener('hy--cookies-ok', function () {
+      gtagConsentUpdateOn();
+    });
+
+    w.loadJSDeferred('https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}');
+  }(window, document);</script>
+{% endif %}


### PR DESCRIPTION
The GA built into this theme is the old UA version which ceased processing data in July.  This sets up GA4 instead.

I've submitted similar code to hydejack in PR330.  Based on other issues/PRs on that repo its not likely to be merged soon.  In this PR I've torn out most of the complexity that I'm unable to test (not having a pro license) and we don't use anyway.

A variation of this was tested on my fork.  

Edit: **GA indicates its received some pings in the last 24 hours so I think this is working.**