### PR TITLE
remove box-shadow in non-functional search bar

### DIFF
--- a/_sass/my-inline.scss
+++ b/_sass/my-inline.scss
@@ -1,0 +1,3 @@
+body .navbar > .content::before {
+  box-shadow: none;
+}


### PR DESCRIPTION
The search feature is part of the pro version of this theme.  We don't use it, but it has a box-shadow on the bottom that looks strange without the search input field inside of it. 

This PR removes that box-shadow.

The screenshot below shows the change.  The screenshot is taken "mid-page", but I'd argue it looks even worse at the top of the page.

Left - current, Right - this PR
![Screen Shot 2023-09-15 at 10 57 10 AM](https://github.com/labzero/guides/assets/1916144/87be4a78-35e3-4bd6-af65-9a0df3ef7504)
