### PR TITLE
Fix links for GitHub page site

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,23 @@ The first `h1` or `#` will automatically become the page title.  You can overrid
 
 #### Links
 
-Use root relative links to other pages.  Don't use github based links.  In general internal links should start with `/`, not `http`.  External links should start with `https://`
+Use relative links to other pages.  Don't use github based links.  In general internal links should not start with `http`.  Instead they should either start with a directory or a file name.  External links should start with `https://`.  Links to other guides should end in `.md`, not `.html`.
+
+These rules ensure the links work from the both the github markdown side, and are properly converted to HTML links for the guides website.
 
 *Don't:*
 ```md
 - [How to Write User Stories](https://github.com/labzero/guides/blob/master/process/how_we_write_user_stories.md)
+- [How to conduct a presentation](process/presentation.html)
+- [File in the same directory](/languages/sibling-document.md)
 - [Our Website](labzero.com)
 ```
 
 Do:
 ```md'
-- [How to Write User Stories](/process/how_we_write_user_stories.md)
+- [How to Write User Stories](process/how_we_write_user_stories.md)
+- [How to conduct a presentation](process/presentation.md)
+- [File in the same directory](sibling-document.md)
 - [Our Website](https://labzero.com)
 ```
 

--- a/languages/ruby/ruby-style-quality-rules.md
+++ b/languages/ruby/ruby-style-quality-rules.md
@@ -8,7 +8,7 @@ title: Ruby coding conventions and quality guidelines
 We use Rubocop, which adheres to this Ruby style guide (https://github.com/bbatsov/ruby-style-guide). See also the related Rails style guide (https://github.com/bbatsov/rails-style-guide) for some good tips (some of which are enforced by Rubocop).
 We generally leave the Rubocop defaults alone, but we have made some changes.
 
-### Where we depart from the defaults:
+## Where we depart from the defaults:
 
 - No max line length (always makes you do something wonky with at least one line somewhere in your code base). That said, if you go significantly over 100 expect to be dinged during PR review unless you have a really good reason / no good alternative.
 
@@ -17,7 +17,7 @@ We generally leave the Rubocop defaults alone, but we have made some changes.
 - Relax some whitespace rules (extra new lines at the beginning / end of blocks) for specs and cukes since block based DSLs are more readable if you can break some rules that work for regular ruby code.
 
 
-### Common mistakes:
+## Common mistakes:
 
 DON'T | DO
  ------- | -----
@@ -28,7 +28,7 @@ Omit spaces inside of {}'s i.e {\|x\| x.foo} | { \|x\| x.foo }
 Use double quotes when not necessary | Only use for strings with interpolation
 Use explicit `self` when not necessary | Only use when attribute may be shadowed by local var / parameter etc. (i.e. almost never)
 
-### Adding Rubocop to your project
+## Adding Rubocop to your project
 Copy this [`.rubocop.yml`](.rubocop.yml) file into the root of your project
 
 Your gemfile should contain:
@@ -40,7 +40,7 @@ Your project's CI rake task should include `sh 'rubocop'`
 
 Feel free to add reasonable `Exclude`s to your `.rubocop.yml`. For example, `schema.rb`, database migrations, cucumber and rspec configuration files (drivers.rb, env.rb, rails_helper.rb etc.). But please, not anything in `app` or `lib` (other than maybe some gnarly rake tasks).
 
-### What this means for you
+## What this means for you
 
 These checks are run during our CI process. To avoid build failures during your PR process, you will want to run the checks yourself locally before submitting a PR (just like specs and cukes).
 To do this, run `rubocop -R` at your project root.

--- a/languages/ruby/ruby_on_rails.md
+++ b/languages/ruby/ruby_on_rails.md
@@ -69,7 +69,8 @@ Be consistent.
 If you have a method more than 10 lines long it’s time to consider refactoring it.  This isn’t to say that no method can be longer than 10 lines, but this should be a clue that your method may be doing too many things.
 
 ## CSS Guidelines
-See our CSS guide at: [https://github.com/labzero/guides/blob/master/languages/css](https://github.com/labzero/guides/blob/master/languages/css)
+
+See our [CSS guide](../css).
 
 ## Beyond MVC
 ### Models vs libs
@@ -112,7 +113,7 @@ For Ruby and/or Rails we should be on the latest patch level (tiny) for the vers
 
 For new Rails (version 7+) apps, decide between a JS bundling tool and import maps. For apps requiring minimal JS use, import maps are efficient and easy. Transitioning to a bundler, later on if needed, is straightforward.
 
-For JS-intensive apps, especially with React, Vue, or Angular, start with a bundler and consider using Typescript.  See also our JS guides and the [Rails guides](https://guides.rubyonrails.org/working_with_javascript_in_rails.html#choosing-between-import-maps-and-a-javascript-bundler).
+For JS-intensive apps, especially with React, Vue, or Angular, start with a bundler and consider using Typescript.  See also our [JS guides](../index.md#javascript--typescript--ecmascript) and the official [Rails guides](https://guides.rubyonrails.org/working_with_javascript_in_rails.html#choosing-between-import-maps-and-a-javascript-bundler).
 
 ## Stimulus & Turbo (Hotwire)
 

--- a/process/accessibility_guide.md
+++ b/process/accessibility_guide.md
@@ -33,7 +33,7 @@ We start with a baseline of readily available tools for testing and add the appr
 ### Planning for accessibility
 
 - [DIY Accessibility Checklists](https://webaccess.berkeley.edu/evaluating/self-assessment/diy-accessibility-checklists)
-- [Screen reader support for hidden content](http://stevefaulkner.github.io/HTML5accessibility/tests/hidden-2016.html)
+- [Screen reader support for hidden content](https://stevefaulkner.github.io/HTML5accessibility/tests/hidden-2016.html)
 - [Accessibility for Teams](https://accessibility.digital.gov/)
 
 ### General accessibility testing

--- a/process/design-review-best-practices.md
+++ b/process/design-review-best-practices.md
@@ -46,7 +46,7 @@ Be mindful of time and table or reschedule topics as needed.
 
 If possible, assign someone to take notes for you. This will allow you more headspace to engage in the conversation.
 
-For detailed tips on how to take part in a review, see our follow-up guide: [best practices for giving and receiving feedback](/process/giving-and-receiving-design-feedback.md). 
+For detailed tips on how to take part in a review, see our follow-up guide: [best practices for giving and receiving feedback](giving-and-receiving-design-feedback.md). 
 
 ## Recap and prioritize 
 Once we’ve received feedback from a critique, we’ll need to process, prioritize, and follow up on what we’ve heard. This allows us to form clear next steps and preserve project momentum.

--- a/process/giving-and-receiving-design-feedback.md
+++ b/process/giving-and-receiving-design-feedback.md
@@ -64,7 +64,7 @@ If you feel like your discussion is getting off topic or you’re getting feedba
 [Adam Connor and Aaron Irizarry, *Discussing Design* (O’Reilly, 2015.)](http://www.discussingdesign.com/)
 Available in handy cheat-sheet form: [http://www.discussingdesign.com/downloads/Critique_CheatSheet.pdf](http://www.discussingdesign.com/downloads/Critique_CheatSheet.pdf)
 
-[Adam Connor, *Discussing Design without Losing Your Mind* (Slide Share, 2014.)](http://www.slideshare.net/adamconnor/discuss-design) 
+[Adam Connor, *Discussing Design without Losing Your Mind* (Slide Share, 2014.)](https://www.slideshare.net/adamconnor/discuss-design) 
 
 Elaine Lin Hering, *Thanks for the Feedback: Skills for Receiving Feedback Well* (Meetup, 2017 based on the book [*Thanks for the Feedback: The Science and Art of Receiving Feedback Well* by Douglas Stone and Sheila Heen (Penguin Books, 2015))](https://www.penguinrandomhouse.com/books/313485/thanks-for-the-feedback-by-douglas-stone-and-sheila-heen/)
 

--- a/process/project_charter_template.md
+++ b/process/project_charter_template.md
@@ -3,7 +3,7 @@
 The following template is useful for cross-functional teams when kicking off a new project with our client-partners.
 
 ## Summary & Objectives
-Link to [speclet](/process/speclet_template.md).
+Link to [speclet](speclet_template.md).
 
 ## Stakeholders
 Who are the main client stakeholders? Fill out the following table: 
@@ -64,7 +64,7 @@ Metrics and hypotheses |  | responsible | consulted | consulted |  |
 Project coordination |  | responsible | assists | assists |  | 
 Stakeholder management | assists | responsible | assists | assists |  | 
 Team health | assists | responsible | assists | assists | assists | assists
-[Speclet](/process/speclet_template.md) |  | responsible | consulted | consulted |  | 
+[Speclet](speclet_template.md) |  | responsible | consulted | consulted |  | 
 Charter |  | responsible | consulted | consulted |  | 
 Personas |  | assists | responsible | consulted |  | 
 Alignment maps |  | assists | responsible | consulted |  | 

--- a/process/speclet_playbook.md
+++ b/process/speclet_playbook.md
@@ -1,6 +1,6 @@
 # Lab Zero Speclet Playbook
 
-Shortcut: [View the template](/process/speclet_template.md).
+Shortcut: [View the template](speclet_template.md).
 
 ## What is a ‘speclet’?
 
@@ -50,4 +50,4 @@ Drafting a speclet can be as simple as writing down what you observe happening t
 
 ## Ready to write your own speclet? 
 
-To jump start your next speclet, [view the template](/process/speclet_template.md).
+To jump start your next speclet, [view the template](speclet_template.md).

--- a/process/speclet_template.md
+++ b/process/speclet_template.md
@@ -1,5 +1,5 @@
 # Lab Zero Speclet Template
-To learn more about speclets, [view the playbook](/process/speclet_playbook.md).
+To learn more about speclets, [view the playbook](speclet_playbook.md).
 
 ## Summary
 This is your space to clarify who the primary customer is, what their core problems/goals are and why the business believes the effort is a worthy investment. 


### PR DESCRIPTION
So, I was wrong about the best way to do links in Jekyll.  It worked in some cases but I found some examples where Jekyll was linking to markdown rather than replacing it with HTML.  I think this works across the board now.

I also found a couple of non-https links and corrected them.