### PR TITLE
Test deployed site links

### DIFF
--- a/.github/workflows/validate-site-links.yml
+++ b/.github/workflows/validate-site-links.yml
@@ -13,4 +13,4 @@ jobs:
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
           url: https://tgaff.github.io/lzguides
-          cmd_params: '--max-connections=3 --color=always --buffer-size=8192 --header="User-Agent:curl/7.54.0" -e (caniuse.com|deque.com|siegemedia.com)'
+          cmd_params: '--max-connections=3 --color=always --buffer-size=8192 --header="User-Agent:curl/7.54.0" -e (caniuse.com|deque.com|contrast-ratio.com|www.amazon.com)'

--- a/.github/workflows/validate-site-links.yml
+++ b/.github/workflows/validate-site-links.yml
@@ -2,7 +2,7 @@
 # If you're operating on a fork, this won't work correctly for you.
 name: Check deployed site links with muffet
 on:
-  push
+  deployment
 
 jobs:
   my-broken-link-checker:
@@ -12,7 +12,7 @@ jobs:
       - name: Check
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
-          url: https://tgaff.github.io/lzguides
+          url: https://guides.labzero.com
           cmd_params: >-
             --max-connections=3
             --color=always

--- a/.github/workflows/validate-site-links.yml
+++ b/.github/workflows/validate-site-links.yml
@@ -13,4 +13,9 @@ jobs:
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
           url: https://tgaff.github.io/lzguides
-          cmd_params: '--max-connections=3 --color=always --buffer-size=8192 --header="User-Agent:curl/7.54.0" -e (caniuse.com|deque.com|contrast-ratio.com|www.amazon.com)'
+          cmd_params: >-
+            --max-connections=3
+            --color=always
+            --buffer-size=8192
+            --header="User-Agent:curl/7.54.0"
+            -e (caniuse.com|deque.com|contrast-ratio.com|www.amazon.com)

--- a/.github/workflows/validate-site-links.yml
+++ b/.github/workflows/validate-site-links.yml
@@ -1,0 +1,16 @@
+# This validates links on the site after it's deployed
+# If you're operating on a fork, this won't work correctly for you.
+name: Check deployed site links with muffet
+on:
+  deployment
+
+jobs:
+  my-broken-link-checker:
+    name: Check broken links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check
+        uses: ruzickap/action-my-broken-link-checker@v2
+        with:
+          url: https://guides.labzero.com
+          cmd_params: '--max-connections=3 --color=always --buffer-size=8192 --header="User-Agent:curl/7.54.0"'

--- a/.github/workflows/validate-site-links.yml
+++ b/.github/workflows/validate-site-links.yml
@@ -12,5 +12,5 @@ jobs:
       - name: Check
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
-          url: https://guides.labzero.com
+          url: https://tgaff.github.io/lzguides
           cmd_params: '--max-connections=3 --color=always --buffer-size=8192 --header="User-Agent:curl/7.54.0"'

--- a/.github/workflows/validate-site-links.yml
+++ b/.github/workflows/validate-site-links.yml
@@ -13,4 +13,4 @@ jobs:
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
           url: https://tgaff.github.io/lzguides
-          cmd_params: '--max-connections=3 --color=always --buffer-size=8192 --header="User-Agent:curl/7.54.0"'
+          cmd_params: '--max-connections=3 --color=always --buffer-size=8192 --header="User-Agent:curl/7.54.0" -e (caniuse.com|deque.com|siegemedia.com)'

--- a/.github/workflows/validate-site-links.yml
+++ b/.github/workflows/validate-site-links.yml
@@ -2,7 +2,7 @@
 # If you're operating on a fork, this won't work correctly for you.
 name: Check deployed site links with muffet
 on:
-  deployment
+  push
 
 jobs:
   my-broken-link-checker:

--- a/README.md
+++ b/README.md
@@ -189,11 +189,14 @@ There are two github actions.
 * Uses Lychee.  
 * Tests the markdown **directly**. It does not load Jekyll or github pages.  
   * This helps to ensure that links are correct on both github.com and on the github-pages site.
-* use `.lycheeignore` to ignore files - it applies to both testers
+* Use `.lycheeignore` to ignore files.
 
 ##### site tester
 
 * Uses muffet, not lychee.
 * Runs after a github pages deploy
-* fetches from https://guides.labzero.com, testing the deployed HTML pages
-* running the site tester too often might annoy github :shrug: not sure
+* Fetches from https://guides.labzero.com, testing the deployed HTML pages.
+* Running the site tester too often might annoy github :shrug: not sure.
+* Edit the task's `-e` (exclude) argument to exclude a site/page.
+  * Some domains reject muffet (masquerading) as curl.
+  * Muffet also checks internal section links like `#some-id`.  Lychee misses errors in these as long as a page loads.

--- a/README.md
+++ b/README.md
@@ -179,7 +179,21 @@ This is not supported.  Github has instructions for doing this but we haven't se
 
 ### Tests
 
+There are two github actions.
 
-1) PRs are tested to verify their links are correct and pointing to a real page.
+1) _PRs_ are tested to verify their links are correct and pointing to a real page.
+2) _Site deploys_ are tested post-deploy to verify links all point to a real page/address.
 
-This uses lychee.  It tests in raw markdown format, without Jekyll or github pages.  This ensures the links work on the gh-pages site and in the github repo markdown.
+##### PR tester
+
+* Uses Lychee.  
+* Tests the markdown **directly**. It does not load Jekyll or github pages.  
+  * This helps to ensure that links are correct on both github.com and on the github-pages site.
+* use `.lycheeignore` to ignore files - it applies to both testers
+
+##### site tester
+
+* Uses muffet, not lychee.
+* Runs after a github pages deploy
+* fetches from https://guides.labzero.com, testing the deployed HTML pages
+* running the site tester too often might annoy github :shrug: not sure

--- a/technical_guides/dev_ops_runbook_guide.md
+++ b/technical_guides/dev_ops_runbook_guide.md
@@ -1,4 +1,4 @@
-- [Runbook Guide](#runbook-guide)
+- [Runbook Guide](#devops-runbook-guide)
     - [Runbooks: A Jumping-Off Point](#runbooks-a-jumping-off-point)
     - [Playbooks and Runbooks are Different](#playbooks-and-runbooks-are-different)
     - [Everyone Uses the Runbook](#everyone-uses-the-runbook)

--- a/vision_and_roadmap/customer_development_playbook.md
+++ b/vision_and_roadmap/customer_development_playbook.md
@@ -252,7 +252,7 @@ We keep the following interview techniques in mind to ensure effective communica
 
 **Five Whys Technique:** Originally developed by Toyota and adopted by lean methodologies among others, this iterative questioning technique is used to determine root causes of problems. If the customer says something, the interviewer can simply ask “_Why?_” to try to learn more. Not all problems have a single root cause, so it is helpful to assess possible nuances.   
 
-**Consider a topic map instead of a script:** When we are worried about coming across as too formal or robotic to the customer, we consider this advanced technique of writing down questions in the form of a ‘topic map’ instead of a linear script. Author Christina Wodtke promoted this idea in her blog post, [“Five Habits of Design Thinking”](https://medium.com/@cwodtke/five-habits-of-design-thinking-45bb61b30393#---0-464).  
+**Consider a topic map instead of a script:** When we are worried about coming across as too formal or robotic to the customer, we consider this advanced technique of writing down questions in the form of a ‘topic map’ instead of a linear script. Author Christina Wodtke promoted this idea in her blog post, [“Five Habits of Design Thinking”](https://medium.com/@cwodtke/five-habits-of-design-thinking-45bb61b30393).  
 
 **Thank the customer:** Finally, we always end the interview by thanking the customer for their time and providing contact information in case they think of anything else after the interview.   
 
@@ -310,7 +310,7 @@ We hope this helps. If you have questions about your customers and want to talk 
 
 This playbook is inspired by many authors and practitioners in the product design space, including the following. 
 
-- Steve Blank, Author of [The Startup Owner's Manual](https://www.amazon.com/gp/product/0984999302/ref=as_li_tf_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=0984999302&linkCode=as2&tag=wwwsteveblank-20)
+- Steve Blank, Author of [The Startup Owner's Manual](https://www.amazon.com/gp/product/0984999302/)
 - Erika Hall, Designer and Author of [Just Enough Research](https://abookapart.com/products/just-enough-research) 
 - [Justin Wilcox](https://customerdevlabs.com/2013/11/05/how-i-interview-customers/?utm_source=CDL+Fit+Workshop+-+Email+Course+Enrollees&utm_campaign=f0333a0e89-Interviewing_Course_Email_3&utm_medium=email&utm_term=0_583a7a794d-f0333a0e89-86026813&mc_cid=f0333a0e89&mc_eid=7e3a0c7b44), Customer Development Labs
 - [Christina Wodtke](http://eleganthack.com/), Designer and Author


### PR DESCRIPTION
This crawls and tests site links post-deploy.   Its a separate tool - too many issues using the lychee tool to do this.

* Some sites reject this bot - I've excluded them rather than trying to fake a User-Agent they might like
* Don't run this too often - I've seen Google drive at least get annoyed and block it

----------

I can't find a way to do this with lychee.  It doesn't support recursion so it can't just crawl the site.  I tried using the markdown to generate the links and map them with `--base ` but it's remap functionality isn't, well, _functional_ enough to convert links from `.md` to `.html`

The muffet output is harder to parse.
![Screen Shot 2023-10-11 at 11 42 29 AM](https://github.com/labzero/guides/assets/1916144/e7c06d1a-ffe8-4449-9f28-47a86fc4b6a0)

