### PR TITLE
Fix site check race condition

### DIFF
--- a/.github/workflows/validate-site-links.yml
+++ b/.github/workflows/validate-site-links.yml
@@ -2,10 +2,11 @@
 # If you're operating on a fork, this won't work correctly for you.
 name: Check deployed site links with muffet
 on:
-  deployment
+  deployment_status
 
 jobs:
   my-broken-link-checker:
+    if: github.event.deployment_status.state == 'success'
     name: Check broken links
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -194,9 +194,11 @@ There are two github actions.
 ##### site tester
 
 * Uses muffet, not lychee.
-* Runs after a github pages deploy
+* Runs after a github page deploy.
 * Fetches from https://guides.labzero.com, testing the deployed HTML pages.
 * Running the site tester too often might annoy github :shrug: not sure.
 * Edit the task's `-e` (exclude) argument to exclude a site/page.
   * Some domains reject muffet (masquerading) as curl.
   * Muffet also checks internal section links like `#some-id`.  Lychee misses errors in these as long as a page loads.
+
+> Note: the worker actually runs and bails out for every `deployment_status`.  It only truly runs the checks on a successful deploy.  The `meh` icons in the Action console can be a little confusing without this knowledge.  This is done to ensure that the worker doesn't run until the deployment is complete.


### PR DESCRIPTION
The previous PRs merge revealed that relying on the `deployment` status results in a race condition.  The `deployment` status is issued when the deploy starts - meaning the tests will run against the already deployed site or parts of the old and new.  I was worried that might be the case but hadn't encountered evidence yet.  Merging that PR proved it as the fixes in that PR were flagged as *not fixed* :-/

This switches to the `deployment_status` trigger which is triggered for each change in a deployment.  

There is no `deployment_success` trigger.  That means this one runs *every time* a deploy status happens including intermediary ones.  We can only filter those out further down in the actual job.  That's not the end of the world but it does mean that several of these jobs show up to work, look at the status and go back home.  They leave what I'm calling a `meh` icon in the actions tab, but don't seem to leave a status on the commit.  That seems "ok".

The final worker that shows up gets to see the success and actually test.

Here's what you'll see if you're looking at actions.  (the red was me testing what happens on failure)
<img width="581" alt="Screen Shot 2023-10-11 at 3 31 42 PM" src="https://github.com/labzero/guides/assets/1916144/7d85830d-0768-47a2-b9a2-383d450831bb">

