### PR TITLE
rework documentation on links

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,28 +29,28 @@ The first `h1` or `#` will automatically become the page title.  You can overrid
 
 #### Links
 
-Use relative links to other pages.  Don't use github.com based links.  In general internal links should not start with `http`.  Instead they should either start with a directory or a file name.  External links should start with `https://`.  Links to other guides should end in `.md`, not `.html`.
+Use relative links to other pages.  Don't use github.com based links.  In general internal links should not start with `http`.  Instead they should either start with a directory, a file name or `../`.  Links to other guides should end in `.md`, not `.html`.  External links should start with `https://` and not point to restricted pages requiring an LZ account to view.
 
 These rules ensure the links work on github.com, and are properly converted to HTML links for the deployed guides website.
 
 *Don't:*
 
 ```md
-1. [Link to a file in the github.com repo](https://github.com/labzero/guides/blob/master/product_design/how_we_write_user_stories.md)
-1. [Link starting with `/`](/process/presentation.md) (only works at the root of the repo)
 1. [.html file suffix](process/making-decisions.html)
-1. [File in the same directory](languages/sibling-document.md)
-1. [Bare URL](labzero.com)
+2. [File in the same directory](languages/sibling-document.md)
+3. [Page in a different directory using `/`](/other-dir/presentation.md) (only works on root level pages)
+4. [Bare URL](labzero.com)
+5. [Link to a file in the github.com repo](https://github.com/labzero/guides/blob/master/product_design/how_we_write_user_stories.md)
 ```
 
 Do:
 
 ```md
-1. [Relative link from within another directory](../product_design/how_we_write_user_stories.md)
-1. [Relative link not starting with `/`](process/presentation.md)
 1. [.md file extension](process/making-decisions.md)
-1. [File in the same directory](sibling-document.md)
-1. [HTTPS URL](https://labzero.com)
+2. [File in the same directory](sibling-document.md)
+3. [Relative link not starting with `/`](../other-dir/presentation.md)
+4. [HTTPS URL](https://labzero.com)
+5. [Relative link from within another directory](../product_design/how_we_write_user_stories.md)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -29,24 +29,28 @@ The first `h1` or `#` will automatically become the page title.  You can overrid
 
 #### Links
 
-Use relative links to other pages.  Don't use github based links.  In general internal links should not start with `http`.  Instead they should either start with a directory or a file name.  External links should start with `https://`.  Links to other guides should end in `.md`, not `.html`.
+Use relative links to other pages.  Don't use github.com based links.  In general internal links should not start with `http`.  Instead they should either start with a directory or a file name.  External links should start with `https://`.  Links to other guides should end in `.md`, not `.html`.
 
-These rules ensure the links work from the both the github markdown side, and are properly converted to HTML links for the guides website.
+These rules ensure the links work on github.com, and are properly converted to HTML links for the deployed guides website.
 
 *Don't:*
+
 ```md
-- [How to Write User Stories](https://github.com/labzero/guides/blob/master/product_design/how_we_write_user_stories.md)
-- [How to conduct a presentation](process/presentation.html)
-- [File in the same directory](/languages/sibling-document.md)
-- [Our Website](labzero.com)
+1. [Link to a file in the github.com repo](https://github.com/labzero/guides/blob/master/product_design/how_we_write_user_stories.md)
+1. [Link starting with `/`](/process/presentation.md) (only works at the root of the repo)
+1. [.html file suffix](process/making-decisions.html)
+1. [File in the same directory](languages/sibling-document.md)
+1. [Bare URL](labzero.com)
 ```
 
 Do:
-```md'
-- [How to Write User Stories](/product_design/how_we_write_user_stories.md)
-- [How to conduct a presentation](/process/presentation.md)
-- [File in the same directory](sibling-document.md)
-- [Our Website](https://labzero.com)
+
+```md
+1. [Relative link from within another directory](../product_design/how_we_write_user_stories.md)
+1. [Relative link not starting with `/`](process/presentation.md)
+1. [.md file extension](process/making-decisions.md)
+1. [File in the same directory](sibling-document.md)
+1. [HTTPS URL](https://labzero.com)
 ```
 
 
@@ -55,7 +59,7 @@ For intra-page links to headings (e.g. `my-page#some-heading`).  Use the heading
 Example:
 
 ```md
-If this page is `meetings.md`, one can link to the section below like:
+If this file is `meetings.md`, one can link to the section below like:
 [online meetings](meetings.md#conducting-an-online-meeting)
 
 
@@ -75,7 +79,7 @@ https://github.com/labzero/guides/blob/master/assets/images/lz-logo.svg
 
 Do:
 ```
-assets/images/lz-logo.svg
+../assets/images/lz-logo.svg
 ```
 
 #### file naming

--- a/index.md
+++ b/index.md
@@ -22,7 +22,7 @@ Feel free to explore, and if anything catches your attention or raises questions
 ## Vision & Roadmap
 
 - [Customer Development](vision_and_roadmap/customer_development_playbook.md)
-- [Product Speclet](vision_and_roadmap/speclet.md) + [Template](/vision_and_roadmap/speclet_template.md)
+- [Product Speclet](vision_and_roadmap/speclet.md) + [Template](vision_and_roadmap/speclet_template.md)
 - [Visualizing the future of product initiatives as a cross-functional team](vision_and_roadmap/visualizing-product-initiatives.md) + [Template](https://www.figma.com/file/kEVk8PaoLbCqI8liK5Emgh/%5BInitiative-Name%5D-Visualization-Summary?type=whiteboard&node-id=0%3A1&t=Dq0dcV75It3GqXxP-1)
 
 ## Product Design

--- a/index.md
+++ b/index.md
@@ -11,42 +11,42 @@ Feel free to explore, and if anything catches your attention or raises questions
 
 ## Project Kickoff
 
-- [Project Charter](/project_kickoff/project_charter.md)
-- [Sprint Ceremonies](/project_kickoff/ceremonies.md)
-- [Definition of Ready](/project_kickoff/definition-of-ready.md)
-- [Definition of Done](/project_kickoff/dod.md)
-- [Team Norms](/project_kickoff/team_norms.md)
-- [Meeting Etiquette](/project_kickoff/meeting-etiquette.md)
-- [Securing Your Workspace](/project_kickoff/securing_your_workspace.md)
+- [Project Charter](project_kickoff/project_charter.md)
+- [Sprint Ceremonies](project_kickoff/ceremonies.md)
+- [Definition of Ready](project_kickoff/definition-of-ready.md)
+- [Definition of Done](project_kickoff/dod.md)
+- [Team Norms](project_kickoff/team_norms.md)
+- [Meeting Etiquette](project_kickoff/meeting-etiquette.md)
+- [Securing Your Workspace](project_kickoff/securing_your_workspace.md)
 
 ## Vision & Roadmap
 
-- [Customer Development](/vision_and_roadmap/customer_development_playbook.md)
-- [Product Speclet](/vision_and_roadmap/speclet.md) + [Template](/vision_and_roadmap/speclet_template.md)
-- [Visualizing the future of product initiatives as a cross-functional team](/vision_and_roadmap/visualizing-product-initiatives.md) + [Template](https://www.figma.com/file/kEVk8PaoLbCqI8liK5Emgh/%5BInitiative-Name%5D-Visualization-Summary?type=whiteboard&node-id=0%3A1&t=Dq0dcV75It3GqXxP-1)
+- [Customer Development](vision_and_roadmap/customer_development_playbook.md)
+- [Product Speclet](vision_and_roadmap/speclet.md) + [Template](/vision_and_roadmap/speclet_template.md)
+- [Visualizing the future of product initiatives as a cross-functional team](vision_and_roadmap/visualizing-product-initiatives.md) + [Template](https://www.figma.com/file/kEVk8PaoLbCqI8liK5Emgh/%5BInitiative-Name%5D-Visualization-Summary?type=whiteboard&node-id=0%3A1&t=Dq0dcV75It3GqXxP-1)
 
 ## Product Design
 
-- [Design Principles](/product_design/design_principles.md)
-- [Design Review](/product_design/design-review-best-practices.md)
-- [Giving and Receiving Feedback](/product_design/giving-and-receiving-design-feedback.md)
-- [How to Write User Stories](/product_design/how_we_write_user_stories.md)
-- [Accessibility](/product_design/accessibility_guide.md)
+- [Design Principles](product_design/design_principles.md)
+- [Design Review](product_design/design-review-best-practices.md)
+- [Giving and Receiving Feedback](product_design/giving-and-receiving-design-feedback.md)
+- [How to Write User Stories](product_design/how_we_write_user_stories.md)
+- [Accessibility](product_design/accessibility_guide.md)
 
 ## Continuous Delivery
 
-- [Development Workflow](/continuous_delivery/development_workflow.md)
-- [Testing Strategy](/continuous_delivery/testing_strategy.md)
-- [Git Commit Guide](/continuous_delivery/commit_guide.md)
-- [README Guide](/continuous_delivery/readme_guide.md)
-- [Sprint Demo Guide](/continuous_delivery/demo_guide.md)
+- [Development Workflow](continuous_delivery/development_workflow.md)
+- [Testing Strategy](continuous_delivery/testing_strategy.md)
+- [Git Commit Guide](continuous_delivery/commit_guide.md)
+- [README Guide](continuous_delivery/readme_guide.md)
+- [Sprint Demo Guide](continuous_delivery/demo_guide.md)
 
 ## Technical Guides
 
-- [Ruby on Rails](/technical_guides/ruby_on_rails.md)
-- [Javascript](/technical_guides/javascript-code-style-quality-rules.md)
-- [Testing React Applications](/technical_guides/react-testing.md)
+- [Ruby on Rails](technical_guides/ruby_on_rails.md)
+- [Javascript](technical_guides/javascript-code-style-quality-rules.md)
+- [Testing React Applications](technical_guides/react-testing.md)
 - [CSS](technical_guides/css.md)
 - [Chef](technical_guides/chef.md)
-- [Dev Ops Runbook Guide](/technical_guides/dev_ops_runbook_guide.md)
+- [Dev Ops Runbook Guide](technical_guides/dev_ops_runbook_guide.md)
 


### PR DESCRIPTION
Tracey and Ned reported that the documentation on how to write links on the guides site was incorrect.  It very much was.  

These changes are intended to fix that documentation and hopefully make it a little easier to understand.

When reviewing I recommend clicking this button to make reading more friendly:

<img width="265" alt="Screen Shot 2023-10-24 at 2 51 36 PM" src="https://github.com/labzero/guides/assets/1916144/2c35eb80-4bda-4316-ba08-633557b43156">

